### PR TITLE
Configure Angular app for Vercel deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,16 @@ Run `ng generate component component-name` to generate a new component. You can 
 
 ## Build
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
+Run `npm run build` to create a production build. The build artifacts are written to `dist/`.
+
+## Deploying to Vercel
+
+This repository is configured for static deployment on Vercel:
+
+1. Import the repo in Vercel.
+2. Leave framework preset as **Other**.
+3. Vercel uses `npm run vercel-build` and publishes the `dist/` directory (configured in `vercel.json`).
+4. SPA routing is handled by a rewrite to `index.html`.
 
 ## Running unit tests
 

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
+    "build": "ng build --configuration production",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "deploy": "ng build --prod --base-href 'https://jakefishbain.github.io/boggle/' && ngh"
+    "deploy": "ng build --prod --base-href 'https://jakefishbain.github.io/boggle/' && ngh",
+    "vercel-build": "NODE_OPTIONS=--openssl-legacy-provider ng build --configuration production"
   },
   "private": true,
   "dependencies": {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "version": 2,
+  "buildCommand": "npm run vercel-build",
+  "outputDirectory": "dist",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation

- Prepare the existing Angular 9 app for static deployment on Vercel and ensure the production build runs on modern Node runtimes.
- Provide SPA-friendly routing so client-side routes resolve to `index.html` after deployment.

### Description

- Add `vercel.json` to set Vercel's `buildCommand`, `outputDirectory` as `dist`, and a rewrite from `/(.*)` to `/index.html` for SPA routing.
- Update `package.json` to set `build` to `ng build --configuration production` and add a `vercel-build` script that runs `NODE_OPTIONS=--openssl-legacy-provider ng build --configuration production` to work around OpenSSL changes on recent Node versions.
- Update `README.md` with instructions for deploying the repository to Vercel and note the new `vercel-build` flow.

### Testing

- Ran `npm run build` which failed in this environment with `ERR_OSSL_EVP_UNSUPPORTED` due to OpenSSL changes on Node 20, which is expected for the Angular 9 toolchain in modern Node.
- Ran `npm run vercel-build` which succeeded and produced the production `dist/` build artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb134bd348330beb405950965c8b5)